### PR TITLE
修复按关键字checker银行股信息时，不良贷款率，不良贷款拨备覆盖率结果为资本充足率的值的bug

### DIFF
--- a/core/checker.go
+++ b/core/checker.go
@@ -418,10 +418,10 @@ func (c Checker) CheckFundamentals(ctx context.Context, stock models.Stock) (res
 
 		checkItemName = "不良贷款率"
 		itemOK = true
-		desc = fmt.Sprintf("不良贷款率:%f", fmd.Newcapitalader)
+		desc = fmt.Sprintf("不良贷款率:%f", fmd.NonPerLoan)
 		if c.Options.BankMaxBLDKL != 0 {
 			if fmd.NonPerLoan > c.Options.BankMaxBLDKL {
-				desc = fmt.Sprintf("不良贷款率:%f</br>高于:%f", fmd.Newcapitalader, c.Options.BankMinZBCZL)
+				desc = fmt.Sprintf("不良贷款率:%f</br>高于:%f", fmd.NonPerLoan, c.Options.BankMaxBLDKL)
 				ok = false
 				itemOK = false
 			}
@@ -433,9 +433,9 @@ func (c Checker) CheckFundamentals(ctx context.Context, stock models.Stock) (res
 
 		checkItemName = "不良贷款拨备覆盖率"
 		itemOK = true
-		desc = fmt.Sprintf("不良贷款拨备覆盖率:%f", fmd.Newcapitalader)
+		desc = fmt.Sprintf("不良贷款拨备覆盖率:%f", fmd.Bldkbbl)
 		if fmd.Bldkbbl < c.Options.BankMinBLDKBBFGL {
-			desc = fmt.Sprintf("不良贷款拨备覆盖率:%f</br>低于:%f", fmd.Newcapitalader, c.Options.BankMinZBCZL)
+			desc = fmt.Sprintf("不良贷款拨备覆盖率:%f</br>低于:%f", fmd.Bldkbbl, c.Options.BankMinBLDKBBFGL)
 			ok = false
 			itemOK = false
 		}


### PR DESCRIPTION
问题原因：不良贷款率、不良贷款拨备覆盖率的值错误使用了资本充足率的值即Newcapitalader。

解决方法：将不良贷款率、不良贷款拨备覆盖率使用正确的值即NonPerLoan、Bldkbbl

验证过程：
使用 q-stock checker -k xyyh 命令查询兴业银行的信息

**| 资本充足率                         | 资本充足率:12.590000              |
+------------------------------------+-----------------------------------+
| 不良贷款率                         | 不良贷款率:12.590000**              |
+------------------------------------+-----------------------------------+
| 负债率                             | 负债率:92.014855                  |
+------------------------------------+-----------------------------------+
**| 不良贷款拨备覆盖率                 | 不良贷款拨备覆盖率:12.590000**



修改后

+--------------------------------------+-----------------------------------+
| **不良贷款拨备覆盖率                   | 不良贷款拨备覆盖率:256.940000**     |
+--------------------------------------+-----------------------------------+
| PEG                                  | PEG:1.055440715292834             |
+--------------------------------------+-----------------------------------+
| 配发股利股息                         | 最新股息率: 4.081425              |
+--------------------------------------+-----------------------------------+
| 行业均值水平估值                     | 低于行业均值水平                  |
+--------------------------------------+-----------------------------------+
| 市值                                 | 市值:4044.73 亿                   |
+--------------------------------------+-----------------------------------+
**| 资本充足率                           | 资本充足率:12.590000**
+--------------------------------------+-----------------------------------+
**| 不良贷款率                           | 不良贷款率:1.150000**               |
+--------------------------------------+-----------------------------------+
